### PR TITLE
Prepare Rust package to be published on crates.io

### DIFF
--- a/src/rust/crate/Cargo.toml
+++ b/src/rust/crate/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "sessionless"
 version = "0.1.0"
+authors = ["FssAy"]
 edition = "2021"
+description = "Implementation of the Sessionless protocol."
+repository = "https://github.com/planet-nine-app/sessionless"
+license = "MIT"
 
 [features]
 default = []

--- a/src/rust/crate/README.md
+++ b/src/rust/crate/README.md
@@ -8,3 +8,6 @@ This crate provides a context to simplify the cryptography operations behind the
 
 ### Features
 - `uuid` - Enables random UUID generation with `Sessionless::generate_uuid`.
+
+### Examples
+All usage examples can be found [here](https://github.com/planet-nine-app/sessionless/tree/main/src/rust/examples).


### PR DESCRIPTION
# Changes
- Added required package metadata fields
- Added "Examples" section to the `README`

_When merged I can publish the crate to the package manager._
