### PR TITLE
Add missing header files for arm-zephyr-eabi toolchain

### DIFF
--- a/src/cpp/client/lib/src/sessionless.cpp
+++ b/src/cpp/client/lib/src/sessionless.cpp
@@ -1,6 +1,7 @@
 #include "sessionless.hpp"
 #include <secp256k1.h>
 #include <random>
+#include <ctime>
 #include <iostream>
 
 bool sessionless::generateKeys(Keys &keys)

--- a/src/cpp/client/lib/src/sessionless.hpp
+++ b/src/cpp/client/lib/src/sessionless.hpp
@@ -2,6 +2,7 @@
 #define SESSIONLESS_HPP
 
 #include <array>
+#include <cstddef>
 
 static constexpr size_t SHA256_SIZE_BYTES = 32;
 static constexpr size_t PRIVATE_KEY_SIZE_BYTES = SHA256_SIZE_BYTES;


### PR DESCRIPTION
The zephyr toolchain requires explicit includes, This is needed for MAGIC project (or any Zephyr hardware targeted projects).