### PR TITLE
fix: kotlin example server (spring boot)

### DIFF
--- a/src/javascript/example/cli/config/local.js
+++ b/src/javascript/example/cli/config/local.js
@@ -1,44 +1,50 @@
 const config = {
   colors: {
     blue: {
-      serverURL: 'http://127.0.0.1:3001',
-      signature: 'payload',
-      language: 'javascript'
+      serverURL: "http://127.0.0.1:3001",
+      signature: "payload",
+      language: "javascript",
     },
     green: {
-      serverURL: 'http://127.0.0.1:5000',
-      signature: 'payload',
-      language: 'python'
+      serverURL: "http://127.0.0.1:5000",
+      signature: "payload",
+      language: "python",
     },
     yellow: {
-      serverURL: 'http://127.0.0.1:3002',
-      signature: 'payload',
-      language: 'typescript'
+      serverURL: "http://127.0.0.1:3002",
+      signature: "payload",
+      language: "typescript",
     },
     red: {
-      serverURL: 'http://127.0.0.1:3000', 
-      signature: 'header',
-      language: 'rust'
+      serverURL: "http://127.0.0.1:3000",
+      signature: "header",
+      language: "rust",
     },
-/*    cyan: {
+    /*    cyan: {
       serverURL: 'http://127.0.0.1:8080',
       signature: 'payload',
       language: 'java'
     },*/
     magenta: {
-      serverURL: 'http://127.0.0.1:5139',
-      signature: 'header',
-      language: 'csharp'
-    }
+      serverURL: "http://127.0.0.1:5139",
+      signature: "header",
+      language: "csharp",
+    },
+    purple: {
+      serverURL: "http://localhost:8080",
+      signature: "payload",
+      language: "kotlin",
+    },
   },
   languages: {
-    javascript: 'blue',
-    typescript: 'yellow',
-    rust: 'red',
-    java: 'bgWhite',
-    csharp: 'magenta',
-    python: 'green'
-  }
+    kotlin: "purple",
+    javascript: "blue",
+    typescript: "yellow",
+    rust: "red",
+    java: "bgWhite",
+    csharp: "magenta",
+    python: "green",
+  },
 };
 
 export default config;

--- a/src/javascript/example/cli/package.json
+++ b/src/javascript/example/cli/package.json
@@ -4,6 +4,7 @@
   "description": "a cli for testing sessionless",
   "main": "main.js",
   "scripts": {
+    "start-kotlin": "node main.js test --color purple",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "type": "module",

--- a/src/kotlin/example/spring/build.gradle.kts
+++ b/src/kotlin/example/spring/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.2.4"
-    id("io.spring.dependency-management") version "1.1.4"
-    kotlin("jvm") version "1.9.23"
-    kotlin("plugin.spring") version "1.9.23"
+    id("org.springframework.boot") version "3.3.2"
+    id("io.spring.dependency-management") version "1.1.6"
+    kotlin("jvm") version "2.0.0"
+    kotlin("plugin.spring") version "2.0.0"
 }
 
 group = "com.planetnine"

--- a/src/kotlin/example/spring/build.gradle.kts
+++ b/src/kotlin/example/spring/build.gradle.kts
@@ -26,7 +26,8 @@ dependencies {
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")
     implementation("org.json:json:20240303")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-
+    implementation("org.reactivestreams:reactive-streams:1.0.4")
+    implementation("org.springframework.boot:spring-boot-starter-webflux:3.3.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/kotlin/example/spring/build.gradle.kts
+++ b/src/kotlin/example/spring/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.3") // Need this guy too, because why would coroutines just need one dependency?
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.session:spring-session-core:3.2.2")
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/controllers/SessionlessController.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/controllers/SessionlessController.kt
@@ -103,7 +103,7 @@ class SessionlessController {
             val enteredText: String?, val timestamp: Long?,
     )
 
-    @PutMapping("/register")
+    @PostMapping("/register")
     fun register(
             req: HttpServletRequest,
             @RequestBody body: RegisterReqBody

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyAccessInfo.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyAccessInfo.kt
@@ -1,0 +1,12 @@
+package com.planetnine.sessionless.impl
+
+/** Information about accessing a key in secure storage
+ * @param alias Key alias (used in storage)
+ * @param password password securing the key pair */
+class KeyAccessInfo(
+    val alias: String,
+    val password: CharArray = CharArray(0)
+) {
+    constructor(alias: String, password: String)
+            : this(alias, password.toCharArray())
+}

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyPairHex.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyPairHex.kt
@@ -1,0 +1,7 @@
+package com.planetnine.sessionless.impl
+
+/** Simplified key pair type, comprised of hex [String]s */
+data class KeyPairHex(
+    val privateKey: String,
+    val publicKey: String
+)

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyStoreVault.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/KeyStoreVault.kt
@@ -1,7 +1,8 @@
-package com.planetnine.sessionless.util.sessionless.impl
+package com.planetnine.sessionless.impl
 
-import com.planetnine.sessionless.util.sessionless.models.vaults.IKeyStoreVault
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils
+import com.planetnine.sessionless.impl.exceptions.KeyPairNotFoundException
+import com.planetnine.sessionless.models.vaults.IKeyStoreVault
+import com.planetnine.sessionless.util.KeyUtils
 import java.security.KeyPair
 import java.security.KeyStore
 import java.security.PrivateKey
@@ -32,14 +33,14 @@ class KeyStoreVault(override val keyStore: KeyStore) : IKeyStoreVault {
         )
     }
 
-    @Throws(
-        java.security.KeyStoreException::class,
-        java.security.NoSuchAlgorithmException::class,
-        java.security.UnrecoverableKeyException::class
-    )
+    @Throws(KeyPairNotFoundException::class)
     override fun get(accessInfo: KeyAccessInfo): KeyPair {
-        val privateKey = keyStore.getKey(accessInfo.alias, accessInfo.password) as PrivateKey
-        val publicKey = keyStore.getCertificate(accessInfo.alias).publicKey
-        return KeyPair(publicKey, privateKey)
+        try {
+            val privateKey = keyStore.getKey(accessInfo.alias, accessInfo.password) as PrivateKey
+            val publicKey = keyStore.getCertificate(accessInfo.alias).publicKey
+            return KeyPair(publicKey, privateKey)
+        } catch (e: Exception) {
+            throw KeyPairNotFoundException(e.message)
+        }
     }
 }

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/MessageSignature.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/MessageSignature.kt
@@ -1,0 +1,57 @@
+package com.planetnine.sessionless.impl
+
+import com.planetnine.sessionless.impl.exceptions.HexFormatRequiredException
+import com.planetnine.sessionless.util.KeyUtils.isBytes
+import java.math.BigInteger
+
+/** Common type for message signatures
+ * - Empty. Used only to indicate that subclasses are similar */
+interface IMessageSignature
+
+/** Message signature as [BigInteger]s */
+open class MessageSignatureInt(
+    val r: BigInteger,
+    val s: BigInteger
+) : IMessageSignature {
+    constructor(ints: Array<BigInteger>)
+            : this(ints[0], ints[1]) {
+        if (ints.size != 2) {
+            throw IllegalArgumentException("Length must be 2")
+        }
+    }
+
+    constructor(signatureHex: MessageSignatureHex)
+            : this(BigInteger(signatureHex.rHex, 16), BigInteger(signatureHex.sHex, 16))
+
+    /** Convert to [MessageSignatureHex] */
+    fun toHex() = MessageSignatureHex(this)
+
+    override fun toString() = toHex().toString()
+}
+
+/** Message signature as hex [String]s */
+open class MessageSignatureHex(
+    val rHex: String,
+    val sHex: String
+) : IMessageSignature {
+    init {
+        if (!rHex.isBytes() || !sHex.isBytes()) {
+            throw HexFormatRequiredException("rHex, sHex")
+        }
+    }
+
+    constructor(rsHex: String, partSize: Int = 64)
+            : this(rsHex.substring(0, partSize), rsHex.substring(partSize)) {
+        if (rsHex.length != partSize * 2) {
+            throw IllegalArgumentException("Length must be $partSize hex characters")
+        }
+    }
+
+    constructor(signatureInt: MessageSignatureInt)
+            : this(signatureInt.r.toString(16), signatureInt.s.toString(16))
+
+    override fun toString() = "$rHex$sHex"
+
+    /** Convert to [MessageSignatureInt] */
+    fun toInt() = MessageSignatureInt(this)
+}

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/MessageSignature.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/MessageSignature.kt
@@ -40,7 +40,8 @@ open class MessageSignatureHex(
         }
     }
 
-    constructor(rsHex: String, partSize: Int = 64)
+    constructor(rsHex: String) : this(rsHex, 64)
+    constructor(rsHex: String, partSize: Int)
             : this(rsHex.substring(0, partSize), rsHex.substring(partSize)) {
         if (rsHex.length != partSize * 2) {
             throw IllegalArgumentException("Length must be $partSize hex characters")

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/Sessionless.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/Sessionless.kt
@@ -24,8 +24,8 @@ import java.util.UUID
 sealed class Sessionless(override val vault: IVault) : ISessionless {
     /** [ISessionless.WithKeyStore] implementation with [Sessionless] as superclass */
     class WithKeyStore(override val vault: KeyStoreVault) :
-            Sessionless(vault),
-            ISessionless.WithKeyStore {
+        Sessionless(vault),
+        ISessionless.WithKeyStore {
 
         override fun generateKeys(keyAccessInfo: KeyAccessInfo): KeyPair {
             val pair = KeyUtils.generateKeyPair()
@@ -40,7 +40,7 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         }
 
         override fun getKeys(keyAccessInfo: KeyAccessInfo): KeyPair =
-                vault.get(keyAccessInfo)
+            vault.get(keyAccessInfo)
 
         override fun sign(message: String, keyAccessInfo: KeyAccessInfo): MessageSignatureHex {
             val privateKey = getKeys(keyAccessInfo).private
@@ -48,8 +48,8 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         }
 
         override fun verifySignature(
-                signedMessage: SignedMessage,
-                keyAccessInfo: KeyAccessInfo
+            signedMessage: SignedMessage,
+            keyAccessInfo: KeyAccessInfo
         ): Boolean {
             val publicKey = getKeys(keyAccessInfo).public
             val withKey = signedMessage.withKey(publicKey)
@@ -59,8 +59,8 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
 
     /** [ISessionless.WithCustomVault] implementation with [Sessionless] as superclass */
     class WithCustomVault(override val vault: ICustomVault) :
-            Sessionless(vault),
-            ISessionless.WithCustomVault {
+        Sessionless(vault),
+        ISessionless.WithCustomVault {
 
         override fun generateKeys(): KeyPairHex {
             val pair = KeyUtils.generateKeyPair()
@@ -81,7 +81,7 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         override fun sign(message: String): MessageSignatureHex {
             // throw if not found (caller should not call this before generating keys)
             val privateString = getKeys()?.privateKey
-                    ?: throw KeyPairNotFoundException()
+                ?: throw KeyPairNotFoundException()
             val privateKey = privateString.toECPrivateKey(KeyUtils.Defaults.parameterSpec)
             return sign(message, privateKey)
         }
@@ -105,7 +105,7 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
     }
 
     override fun verifySignature(signedMessage: SignedMessageWithKey): Boolean =
-            verifySignature(signedMessage.toEC())
+        verifySignature(signedMessage.toEC())
 
     override fun verifySignature(signedMessage: SignedMessageWithECKey): Boolean {
         val signer = ECDSASigner().apply {
@@ -114,9 +114,9 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         val messageHash = signedMessage.message.hashKeccak256()
         val signatureInt = signedMessage.signature.toInt()
         return signer.verifySignature(
-                messageHash,
-                signatureInt.r,
-                signatureInt.s
+            messageHash,
+            signatureInt.r,
+            signatureInt.s
         )
     }
 

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/Sessionless.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/Sessionless.kt
@@ -1,21 +1,18 @@
-package com.planetnine.sessionless.util.sessionless.impl
+package com.planetnine.sessionless.impl
 
-import com.planetnine.sessionless.util.sessionless.impl.Sessionless.WithCustomVault
-import com.planetnine.sessionless.util.sessionless.impl.Sessionless.WithKeyStore
-import com.planetnine.sessionless.util.sessionless.impl.exceptions.KeyPairNotFoundException
-import com.planetnine.sessionless.util.sessionless.models.ISessionless
-import com.planetnine.sessionless.util.sessionless.models.vaults.ICustomVault
-import com.planetnine.sessionless.util.sessionless.models.vaults.IVault
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils.domainParameters
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils.toECHex
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils.toECPrivateKey
-import com.planetnine.sessionless.util.sessionless.util.KeyUtils.toHex
-import com.planetnine.sessionless.util.sessionless.util.hashKeccak256
-import org.bouncycastle.crypto.params.ECPrivateKeyParameters
-import org.bouncycastle.crypto.params.ECPublicKeyParameters
+import com.planetnine.sessionless.impl.Sessionless.WithCustomVault
+import com.planetnine.sessionless.impl.Sessionless.WithKeyStore
+import com.planetnine.sessionless.impl.exceptions.KeyPairNotFoundException
+import com.planetnine.sessionless.models.ISessionless
+import com.planetnine.sessionless.models.vaults.ICustomVault
+import com.planetnine.sessionless.models.vaults.IVault
+import com.planetnine.sessionless.util.KeyUtils
+import com.planetnine.sessionless.util.KeyUtils.toECHex
+import com.planetnine.sessionless.util.KeyUtils.toECPrivateKey
+import com.planetnine.sessionless.util.KeyUtils.toECPrivateKeyParameters
+import com.planetnine.sessionless.util.KeyUtils.toHex
+import com.planetnine.sessionless.util.hashKeccak256
 import org.bouncycastle.crypto.signers.ECDSASigner
-import java.math.BigInteger
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.interfaces.ECPrivateKey
@@ -27,8 +24,8 @@ import java.util.UUID
 sealed class Sessionless(override val vault: IVault) : ISessionless {
     /** [ISessionless.WithKeyStore] implementation with [Sessionless] as superclass */
     class WithKeyStore(override val vault: KeyStoreVault) :
-        Sessionless(vault),
-        ISessionless.WithKeyStore {
+            Sessionless(vault),
+            ISessionless.WithKeyStore {
 
         override fun generateKeys(keyAccessInfo: KeyAccessInfo): KeyPair {
             val pair = KeyUtils.generateKeyPair()
@@ -43,18 +40,27 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         }
 
         override fun getKeys(keyAccessInfo: KeyAccessInfo): KeyPair =
-            vault.get(keyAccessInfo)
+                vault.get(keyAccessInfo)
 
         override fun sign(message: String, keyAccessInfo: KeyAccessInfo): MessageSignatureHex {
             val privateKey = getKeys(keyAccessInfo).private
             return sign(message, privateKey)
         }
+
+        override fun verifySignature(
+                signedMessage: SignedMessage,
+                keyAccessInfo: KeyAccessInfo
+        ): Boolean {
+            val publicKey = getKeys(keyAccessInfo).public
+            val withKey = signedMessage.withKey(publicKey)
+            return verifySignature(withKey)
+        }
     }
 
     /** [ISessionless.WithCustomVault] implementation with [Sessionless] as superclass */
     class WithCustomVault(override val vault: ICustomVault) :
-        Sessionless(vault),
-        ISessionless.WithCustomVault {
+            Sessionless(vault),
+            ISessionless.WithCustomVault {
 
         override fun generateKeys(): KeyPairHex {
             val pair = KeyUtils.generateKeyPair()
@@ -75,63 +81,63 @@ sealed class Sessionless(override val vault: IVault) : ISessionless {
         override fun sign(message: String): MessageSignatureHex {
             // throw if not found (caller should not call this before generating keys)
             val privateString = getKeys()?.privateKey
-                ?: throw KeyPairNotFoundException()
+                    ?: throw KeyPairNotFoundException()
             val privateKey = privateString.toECPrivateKey(KeyUtils.Defaults.parameterSpec)
             return sign(message, privateKey)
+        }
+
+        override fun verifySignature(signedMessage: SignedMessage): Boolean {
+            val pair = getKeys() ?: throw KeyPairNotFoundException()
+            val withKey = signedMessage.withKey(pair.publicKey)
+            return verifySignature(withKey)
         }
     }
 
     override fun sign(message: String, privateKey: PrivateKey): MessageSignatureHex {
+        val privateHex = (privateKey as ECPrivateKey).toHex()
+        val privateKeyParameters = privateHex.toECPrivateKeyParameters()
         val signer = ECDSASigner().apply {
-            val privateHex = (privateKey as ECPrivateKey).toHex()
-            val privateKeyFormatted = BigInteger(privateHex, 16)
-            val privateKeyParameters = ECPrivateKeyParameters(
-                privateKeyFormatted,
-                KeyUtils.Defaults.parameterSpec.domainParameters
-            )
             init(true, privateKeyParameters)
         }
-        val messageHash = hashKeccak256(message)
+        val messageHash = message.hashKeccak256()
         val signatureArray = signer.generateSignature(messageHash)
         return MessageSignatureInt(signatureArray).toHex()
     }
 
-    override fun verifySignature(signedMessage: SignedMessage): Boolean {
-        val signer = ECDSASigner().apply {
-            val publicInt = BigInteger(signedMessage.publicKey, 16)
-            val paramSpec = KeyUtils.Defaults.parameterSpec
-            val publicKeyPoint = paramSpec.curve.decodePoint(publicInt.toByteArray())
-            val publicKeyParameters = ECPublicKeyParameters(
-                publicKeyPoint, paramSpec.domainParameters
-            )
-            init(false, publicKeyParameters)
-        }
-        val messageHash = hashKeccak256(signedMessage.message)
-        val signature = signedMessage.signature.toInt()
-        return signer.verifySignature(
-            messageHash,
-            signature.r,
-            signature.s
-        )
-    }
+    override fun verifySignature(signedMessage: SignedMessageWithKey): Boolean =
+            verifySignature(signedMessage.toEC())
 
-    /** Verifies a given signature with a public key
-     * - This calls [verifySignature] with [SignedMessage] out of the provided parameters
-     * @see verifySignature */
-    fun verifySignature(
-        message: String,
-        publicKey: String,
-        signature: MessageSignatureHex
-    ): Boolean {
-        return verifySignature(SignedMessage(message, publicKey, signature))
+    override fun verifySignature(signedMessage: SignedMessageWithECKey): Boolean {
+        val signer = ECDSASigner().apply {
+            init(false, signedMessage.publicKey)
+        }
+        val messageHash = signedMessage.message.hashKeccak256()
+        val signatureInt = signedMessage.signature.toInt()
+        return signer.verifySignature(
+                messageHash,
+                signatureInt.r,
+                signatureInt.s
+        )
     }
 
     override fun generateUUID(): String = UUID.randomUUID().toString()
 
-    override fun associate(vararg signedMessages: SignedMessage): Boolean {
-        if (signedMessages.size < 2) {
-            throw IllegalArgumentException("Must have at least two messages to associate")
-        }
+
+    override fun associate(vararg signedMessages: SignedMessageWithKey): Boolean {
+        signedMessages.twoOrThrow()
         return signedMessages.all(::verifySignature)
+    }
+
+    override fun associate(vararg signedMessages: SignedMessageWithECKey): Boolean {
+        signedMessages.twoOrThrow()
+        return signedMessages.all(::verifySignature)
+    }
+
+    companion object {
+        private fun <T> Array<T>.twoOrThrow() {
+            if (size < 2) {
+                throw IllegalArgumentException("Must have at least two messages to associate")
+            }
+        }
     }
 }

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/SignedMessage.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/SignedMessage.kt
@@ -1,0 +1,63 @@
+package com.planetnine.sessionless.impl
+
+import com.planetnine.sessionless.impl.exceptions.HexFormatRequiredException
+import com.planetnine.sessionless.util.KeyUtils.isBytes
+import com.planetnine.sessionless.util.KeyUtils.toECPublicKeyParameters
+import com.planetnine.sessionless.util.KeyUtils.toECPublicParameters
+import org.bouncycastle.crypto.params.ECPublicKeyParameters
+import java.security.PublicKey
+
+open class SignedMessage(
+    val message: String,
+    val signature: MessageSignatureHex,
+) {
+
+    fun withKey(publicKey: String) =
+        SignedMessageWithKey(this, publicKey)
+
+    fun withKey(publicKey: PublicKey) =
+        SignedMessageWithECKey(this, publicKey)
+
+    fun withKey(publicKey: ECPublicKeyParameters) =
+        SignedMessageWithECKey(this, publicKey)
+}
+
+class SignedMessageWithKey(
+    message: String,
+    signature: MessageSignatureHex,
+    val publicKey: String,
+) : SignedMessage(message, signature) {
+    init {
+        if (!publicKey.isBytes()) {
+            throw HexFormatRequiredException("publicKey")
+        }
+    }
+
+    constructor(signedMessage: SignedMessage, publicKey: String) :
+            this(signedMessage.message, signedMessage.signature, publicKey)
+
+    fun toEC() = SignedMessageWithECKey(this, publicKey.toECPublicKeyParameters())
+}
+
+class SignedMessageWithECKey(
+    message: String,
+    signature: MessageSignatureHex,
+    val publicKey: ECPublicKeyParameters,
+) : SignedMessage(message, signature) {
+
+    constructor(
+        message: String,
+        signature: MessageSignatureHex,
+        publicKey: PublicKey
+    ) : this(message, signature, publicKey.toECPublicParameters())
+
+    constructor(
+        signedMessage: SignedMessage,
+        publicKey: PublicKey
+    ) : this(signedMessage.message, signedMessage.signature, publicKey)
+
+    constructor(
+        signedMessage: SignedMessage,
+        publicKey: ECPublicKeyParameters
+    ) : this(signedMessage.message, signedMessage.signature, publicKey)
+}

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/exceptions/HexFormatRequiredException.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/exceptions/HexFormatRequiredException.kt
@@ -1,0 +1,4 @@
+package com.planetnine.sessionless.impl.exceptions
+
+class HexFormatRequiredException(target: String? = null) :
+    RuntimeException("Hex format is required" + (if (target == null) "" else ": $target"))

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/exceptions/KeyPairNotFoundException.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/impl/exceptions/KeyPairNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.planetnine.sessionless.impl.exceptions
+
+import java.security.UnrecoverableKeyException
+
+class KeyPairNotFoundException(extra: String? = null) :
+    UnrecoverableKeyException("Key pair was not found" + (if (extra == null) "" else ": $extra"))

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/ISessionless.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/ISessionless.kt
@@ -1,12 +1,14 @@
-package com.planetnine.sessionless.util.sessionless.models
+package com.planetnine.sessionless.models
 
-import com.planetnine.sessionless.util.sessionless.impl.IMessageSignature
-import com.planetnine.sessionless.util.sessionless.impl.KeyAccessInfo
-import com.planetnine.sessionless.util.sessionless.impl.KeyPairHex
-import com.planetnine.sessionless.util.sessionless.impl.KeyStoreVault
-import com.planetnine.sessionless.util.sessionless.impl.SignedMessage
-import com.planetnine.sessionless.util.sessionless.models.vaults.ICustomVault
-import com.planetnine.sessionless.util.sessionless.models.vaults.IVault
+import com.planetnine.sessionless.impl.IMessageSignature
+import com.planetnine.sessionless.impl.KeyAccessInfo
+import com.planetnine.sessionless.impl.KeyPairHex
+import com.planetnine.sessionless.impl.KeyStoreVault
+import com.planetnine.sessionless.impl.SignedMessage
+import com.planetnine.sessionless.impl.SignedMessageWithECKey
+import com.planetnine.sessionless.impl.SignedMessageWithKey
+import com.planetnine.sessionless.models.vaults.ICustomVault
+import com.planetnine.sessionless.models.vaults.IVault
 import java.security.KeyPair
 import java.security.PrivateKey
 
@@ -37,6 +39,13 @@ interface ISessionless {
          * @param keyAccessInfo Info required to access the stored key
          * @return Signature as [IMessageSignature] */
         fun sign(message: String, keyAccessInfo: KeyAccessInfo): IMessageSignature
+
+
+        /** Verifies a given [signedMessage] with the user's stored public key.
+         * See: [sign]
+         * @param signedMessage The message that was signed earlier
+         * @return True if the signature is valid for the given message and public key */
+        fun verifySignature(signedMessage: SignedMessage, keyAccessInfo: KeyAccessInfo): Boolean
     }
 
     interface WithCustomVault : ISessionless {
@@ -54,25 +63,35 @@ interface ISessionless {
          * @return Key pair as [String]s ([KeyPairHex]). */
         fun getKeys(): KeyPairHex?
 
-        /** Signs a [message] with the user's stored private key (from [vault]).
-         * @param message The message to be signed.
+        /** Signs a [message] with the user's stored private key (from [vault])
+         * @param message The message to be signed
          * @return Signature as [IMessageSignature] */
         fun sign(message: String): IMessageSignature
+
+        /** Verifies a given [signedMessage] with the user's stored public key
+         * @param signedMessage The message that was signed earlier
+         * @return True if the signature is valid for the given message and public key */
+        fun verifySignature(signedMessage: SignedMessage): Boolean
     }
 
-    /** Signs a [message] using the provided [privateKey].
-     * @param message The message to be signed.
+    /** Signs a [message] using the provided [privateKey]
+     * @param message The message to be signed
      * @return Signature as [IMessageSignature]. */
     fun sign(message: String, privateKey: PrivateKey): IMessageSignature
 
-    /** Verifies a given signature with a public key.
-     * @param signedMessage message that was signed
-     * @return True if the [SignedMessage.signature] is valid
-     * for the given [SignedMessage.message] and [SignedMessage.publicKey].
-     * @see sign */
-    fun verifySignature(signedMessage: SignedMessage): Boolean
 
-    /** Creates a unique UUID for a user.
+    /** Verifies a given [signedMessage] with the included [SignedMessageWithKey.publicKey]
+     * @param signedMessage The message that was signed earlier
+     * @return True if the signature is valid for the given message and public key */
+    fun verifySignature(signedMessage: SignedMessageWithKey): Boolean
+
+    /** Verifies a given [signedMessage] with the included [SignedMessageWithECKey.publicKey]
+     * @param signedMessage The message that was signed earlier
+     * @return True if the signature is valid for the given message and public key */
+    fun verifySignature(signedMessage: SignedMessageWithECKey): Boolean
+
+
+    /** Creates a unique UUID for a user
      * @return The generated UUID. */
     fun generateUUID(): String
 
@@ -80,7 +99,13 @@ interface ISessionless {
      * @return true if all were successfully verified
      * @throws java.lang.IllegalArgumentException if array size<2
      * @see verifySignature */
-    fun associate(vararg signedMessages: SignedMessage): Boolean
+    fun associate(vararg signedMessages: SignedMessageWithKey): Boolean
+
+    /** Associates [signedMessages] signatures with their respective public keys
+     * @return true if all were successfully verified
+     * @throws java.lang.IllegalArgumentException if array size<2
+     * @see verifySignature */
+    fun associate(vararg signedMessages: SignedMessageWithECKey): Boolean
 
 //    /** Revokes a gateway's key from the user.
 //     * @param message Message for revocation.

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/ICustomVault.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/ICustomVault.kt
@@ -1,6 +1,6 @@
-package com.planetnine.sessionless.util.sessionless.models.vaults
+package com.planetnine.sessionless.models.vaults
 
-import com.planetnine.sessionless.util.sessionless.impl.KeyPairHex
+import com.planetnine.sessionless.impl.KeyPairHex
 
 /** [IVault] which uses custom [save]/[get] methods */
 interface ICustomVault : IVault {

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/IKeyStoreVault.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/IKeyStoreVault.kt
@@ -1,6 +1,6 @@
-package com.planetnine.sessionless.util.sessionless.models.vaults
+package com.planetnine.sessionless.models.vaults
 
-import com.planetnine.sessionless.util.sessionless.impl.KeyAccessInfo
+import com.planetnine.sessionless.impl.KeyAccessInfo
 import java.security.KeyPair
 import java.security.KeyStore
 import java.security.cert.Certificate

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/IVault.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/models/vaults/IVault.kt
@@ -1,7 +1,7 @@
-package com.planetnine.sessionless.util.sessionless.models.vaults
+package com.planetnine.sessionless.models.vaults
 
-import com.planetnine.sessionless.util.sessionless.impl.KeyStoreVault
-import com.planetnine.sessionless.util.sessionless.models.ISessionless
+import com.planetnine.sessionless.impl.KeyStoreVault
+import com.planetnine.sessionless.models.ISessionless
 import java.security.KeyStore
 
 

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/KeyUtils.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/KeyUtils.kt
@@ -71,9 +71,9 @@ object KeyUtils {
     // }
 
     @Throws(
-        java.security.cert.CertificateEncodingException::class,
-        IllegalStateException::class,
-        RuntimeException::class
+            java.security.cert.CertificateEncodingException::class,
+            IllegalStateException::class,
+            RuntimeException::class
     )
     @Suppress("DEPRECATION") //? this works... but it's deprecated.. I didn't find another way
     fun generateSelfSignedCertificate(pair: KeyPair): X509Certificate {
@@ -168,8 +168,8 @@ object KeyUtils {
         if (!this.isBytes()) throw HexFormatRequiredException("(this)")
         val privateInt = BigInteger(this, 16)
         return ECPrivateKeyParameters(
-            privateInt,
-            Defaults.parameterSpec.domainParameters
+                privateInt,
+                Defaults.parameterSpec.domainParameters
         )
     }
 
@@ -179,7 +179,7 @@ object KeyUtils {
         val paramSpec = Defaults.parameterSpec
         val publicKeyPoint = paramSpec.curve.decodePoint(publicInt.toByteArray())
         return ECPublicKeyParameters(
-            publicKeyPoint, paramSpec.domainParameters
+                publicKeyPoint, paramSpec.domainParameters
         )
     }
 
@@ -198,8 +198,8 @@ object KeyUtils {
 
         // compressed/uncompressed point
         val isEvenY = rawY
-            .mod(BigInteger("2"))
-            .equals(BigInteger.ZERO)
+                .mod(BigInteger("2"))
+                .equals(BigInteger.ZERO)
         val prefix = if (isEvenY) "02" else "03"
 
         // absolute raw x to hex

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/KeyUtils.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/KeyUtils.kt
@@ -71,9 +71,9 @@ object KeyUtils {
     // }
 
     @Throws(
-            java.security.cert.CertificateEncodingException::class,
-            IllegalStateException::class,
-            RuntimeException::class
+        java.security.cert.CertificateEncodingException::class,
+        IllegalStateException::class,
+        RuntimeException::class
     )
     @Suppress("DEPRECATION") //? this works... but it's deprecated.. I didn't find another way
     fun generateSelfSignedCertificate(pair: KeyPair): X509Certificate {
@@ -168,8 +168,8 @@ object KeyUtils {
         if (!this.isBytes()) throw HexFormatRequiredException("(this)")
         val privateInt = BigInteger(this, 16)
         return ECPrivateKeyParameters(
-                privateInt,
-                Defaults.parameterSpec.domainParameters
+            privateInt,
+            Defaults.parameterSpec.domainParameters
         )
     }
 
@@ -179,7 +179,7 @@ object KeyUtils {
         val paramSpec = Defaults.parameterSpec
         val publicKeyPoint = paramSpec.curve.decodePoint(publicInt.toByteArray())
         return ECPublicKeyParameters(
-                publicKeyPoint, paramSpec.domainParameters
+            publicKeyPoint, paramSpec.domainParameters
         )
     }
 
@@ -198,8 +198,8 @@ object KeyUtils {
 
         // compressed/uncompressed point
         val isEvenY = rawY
-                .mod(BigInteger("2"))
-                .equals(BigInteger.ZERO)
+            .mod(BigInteger("2"))
+            .equals(BigInteger.ZERO)
         val prefix = if (isEvenY) "02" else "03"
 
         // absolute raw x to hex

--- a/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/hashKeccak256.kt
+++ b/src/kotlin/example/spring/src/main/kotlin/com/planetnine/sessionless/util/sessionless/util/hashKeccak256.kt
@@ -1,6 +1,5 @@
-package com.planetnine.sessionless.util.sessionless.util
+package com.planetnine.sessionless.util
 
 import org.bouncycastle.jcajce.provider.digest.Keccak
 
-fun hashKeccak256(message: String): ByteArray =
-    Keccak.Digest256().digest(message.toByteArray())
+fun String.hashKeccak256(): ByteArray = Keccak.Digest256().digest(toByteArray())

--- a/src/kotlin/standalone/sessionless/build.gradle.kts
+++ b/src/kotlin/standalone/sessionless/build.gradle.kts
@@ -1,13 +1,18 @@
 plugins {
-    id("java-library")
-    kotlin("jvm") version "1.9.23"
+    kotlin("jvm") version "2.0.0"
+    `java-library`
+    `maven-publish`
 }
+
+group = "com.planetnineapp.sessionless-kt"
+version = "1.0.0"
 
 repositories {
     mavenCentral()
 }
 
 java {
+    withSourcesJar()
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
@@ -15,8 +20,17 @@ java {
 dependencies {
     implementation(kotlin("script-runtime"))
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
-    implementation("org.bouncycastle:bcprov-jdk18on:1.77")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     implementation("org.json:json:20240303")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
+}
+
+tasks.jar {
+    manifest {
+        attributes(mapOf(
+            "Implementation-Title" to project.name,
+            "Implementation-Version" to project.version
+        ))
+    }
 }


### PR DESCRIPTION
# Server
- fix response return type to use `ResponseEntity`
- fix the message that's being verified in both `/register` and `/cool-stuff`
  - json entries' order (manually generate json to ensure order)
- add missing dependency
- change endpoints' methods from PUT to POST
- bump kotlin version to 2.0 along with some packages
- bump sessionless to current latest files (TODO: use maven package when released)
- maybe more idk

# Rainbow test

- add kotlin to client colors (as purple)

# Sessionless lib
- some publishing preparation