### PR TITLE
Add TypeScript type declarations for Node package

### DIFF
--- a/src/javascript/node/package.json
+++ b/src/javascript/node/package.json
@@ -11,6 +11,7 @@
     "import": "./sessionless.js",
     "require": "./sessionless.cjs"
   },
+  "types": "sessionless.d.ts",
   "author": "Zach Babb",
   "license": "MIT",
   "dependencies": {

--- a/src/javascript/node/sessionless.d.ts
+++ b/src/javascript/node/sessionless.d.ts
@@ -6,8 +6,8 @@ export declare interface Keys {
 }
 
 export declare const generateKeys: (
-  getKeys: () => {},
-  saveKeys: () => {},
+  getKeys: () => Keys,
+  saveKeys: () => void,
 ) => Promise<Keys>;
 
 export declare const getKeys: () => Keys;

--- a/src/javascript/node/sessionless.d.ts
+++ b/src/javascript/node/sessionless.d.ts
@@ -1,0 +1,27 @@
+export declare const AsyncFunction: (func: () => {}) => void;
+
+export declare const generateKeys: (
+  getKeys: () => {},
+  saveKeys: () => {},
+) => Promise<{ privateKey: string; publicKey: string }>;
+
+export declare const getKeys: () => { privateKey: string; publicKey: string };
+
+export declare const sign: (message: string) => Promise<string>;
+
+export declare const verifySignature: (
+  sig: string,
+  message: string,
+  pubKey: string,
+) => boolean;
+
+export declare const generateUUID: () => string;
+
+export declare const associate: (
+  primarySignature: string,
+  primaryMessage: string,
+  primaryPublicKey: string,
+  secondarySignature: string,
+  secondaryMessage: string,
+  secondaryPublicKey: string,
+) => boolean;

--- a/src/javascript/node/sessionless.d.ts
+++ b/src/javascript/node/sessionless.d.ts
@@ -1,11 +1,16 @@
 export declare const AsyncFunction: (func: () => {}) => void;
 
+export declare interface Keys {
+  privateKey: string;
+  publicKey: string;
+}
+
 export declare const generateKeys: (
   getKeys: () => {},
   saveKeys: () => {},
-) => Promise<{ privateKey: string; publicKey: string }>;
+) => Promise<Keys>;
 
-export declare const getKeys: () => { privateKey: string; publicKey: string };
+export declare const getKeys: () => Keys;
 
 export declare const sign: (message: string) => Promise<string>;
 


### PR DESCRIPTION
initially introduced in #77 (stale), picking it back up now

- **[feat] type declarations for Node package as per requested changes in #77**
- **[refactor] add Keys interface to Node type declarations**
- **update Node package.json to include type declarations**
